### PR TITLE
Disable python, disable-statedir, add pcre

### DIFF
--- a/watchman.spec
+++ b/watchman.spec
@@ -1,5 +1,3 @@
-%global pyversion 1.4.0
-
 Name:    watchman
 Version: 4.9.0
 Release: 2%{?dist}
@@ -14,8 +12,7 @@ BuildRequires: make
 BuildRequires: autoconf
 BuildRequires: automake
 BuildRequires: openssl-devel
-BuildRequires: python3-devel
-BuildRequires: python3dist(setuptools)
+BuildRequires: pcre
 
 %description
 Watches files and records, or triggers actions, when they change.
@@ -26,7 +23,7 @@ Watches files and records, or triggers actions, when they change.
 
 # See https://github.com/facebook/watchman/issues/638 as to why --enable-lenient
 # is required.
-%configure --enable-lenient --with-python=%{__python3}
+%configure --enable-lenient --without-python --disable-statedir
 
 %build
 %make_build
@@ -39,14 +36,11 @@ Watches files and records, or triggers actions, when they change.
 make install DESTDIR=%{buildroot}
 mkdir %{buildroot}%{_docdir}/%{name}
 rm -rf %{buildroot}%{_docdir}/%{name}-%{version}
-rm -rf %{buildroot}%{_usr}/var/run/watchman
-rm -rf %{buildroot}%{python3_sitearch}/py%{name}-%{pyversion}-py%{python3_version}.egg-info
 
 %files
 %defattr(-,root,root,-)
 %doc README.markdown
 %attr(0755,root,root) %{_bindir}/watchman{,-make,-wait}
-%{python3_sitearch}/pywatchman
 
 %changelog
 * Thu Nov 22 2018 Evan Klitzke <evan@eklitzke.org>


### PR DESCRIPTION
statedir doesn't work for me see https://github.com/facebook/watchman/issues/817

I don't need with python dev lib but I can re-enable it if you like

not sure how to edit the changelog of a `.spec` file - is there some kind of tool? looks error-prone by hand

pcre seems to be required

and finally for some reason dnf cannot find watchman in your copr https://copr.fedorainfracloud.org/coprs/eklitzke/watchman/

(Fedora 32)